### PR TITLE
Use latest api version when get resource fails

### DIFF
--- a/stormcollector/stormcollector/arm.py
+++ b/stormcollector/stormcollector/arm.py
@@ -39,7 +39,7 @@ async def _query_resource(
                 return await _query_resource(
                     client,
                     resource_id,
-                    api_version=api_versions[0],
+                    api_version=api_versions[-1],
                     invalid_versions=invalid_versions,
                 )
 

--- a/stormcollector/stormcollector/arm.py
+++ b/stormcollector/stormcollector/arm.py
@@ -30,8 +30,8 @@ async def _query_resource(
         if "No registered resource provider found for location" in ex.message:
             invalid_versions.append(api_version)
             api_versions = re.search(
-                "The supported api-versions are '(.*?),", ex.message
-            ).groups()
+                "The supported api-versions are '(.*?)'. The supported locations", ex.message
+            ).groups()[0].split(', ')
             api_versions = list(
                 filter(lambda v: v not in invalid_versions, api_versions)
             )


### PR DESCRIPTION
Currently when  query_resource fails due to an invalid api-version, it tries again with the earliest version available. I noticed the issue because nsg rules weren't parsing correctly.

This commit updates the regex to build the list correctly then tries the last item in the filtered list.