### PR TITLE
Updated README.md to direct users to get stormcollector pyz file from releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can then visit http://localhost:9091 in your browser.
 
 ### Stormcollector
 
-Stormcollector is the portion of Stormspotter that allows you to enumerate the subscriptions the provided credentials have access to. The **_RECOMMENDED_** way to use Stormcollector is to run the `sscollector.pyz` package. This PYZ has been created with [Shiv](https://github.com/linkedin/shiv) and comes with all the packages already zipped up! The dependencies will extract themselves to a `.shiv` folder in the user's home directory.
+Stormcollector is the portion of Stormspotter that allows you to enumerate the subscriptions the provided credentials have access to. The **_RECOMMENDED_** way to use Stormcollector is to run the `sscollector.pyz` package, found in [the release file for your operating system](https://github.com/Azure/Stormspotter/releases/). This PYZ has been created with [Shiv](https://github.com/linkedin/shiv) and comes with all the packages already zipped up! The dependencies will extract themselves to a `.shiv` folder in the user's home directory.
 
 ```
 cd stormcollector


### PR DESCRIPTION
As a first-time user, possibly not drinking enough coffee, I initially thought the sscollector.pyz file would be found in the GitHub repo clone that is the preferred method of installation for StormSpotter.  I've added a phrase and a link to direct people to the releases page to get this file.