### PR TITLE
Fix: neo4j version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ networks:
 
 services:
   stormspotter-neo4j:
-    image: neo4j:latest
+    image: neo4j:3.5.18
     restart: unless-stopped
     networks:
       - stormspotter-network

--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -2,7 +2,7 @@ FROM node:12-alpine
 ENV VUE_APP_UPLOAD_URL=http://stormspotter-backend:9090/api/upload
 
 WORKDIR /usr/src/app
-RUN npm install -g @quasar/cli
+RUN npm install -g @quasar/cli@1.1.1
 
 COPY dist/spa .
 EXPOSE 9091

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "cytoscape-klay": "^3.1.3",
     "flush-promises": "^1.0.2",
     "lodash": "^4.17.20",
-    "quasar": "^1.13.2",
+    "quasar": "^1.14.3",
     "vue-codemirror": "^4.0.6",
     "vue-cytoscape": "^1.0.8",
     "vue-loader": "^15.9.3",


### PR DESCRIPTION
neo4j:latest is broken - errors a type mismatch with stormspotter. Downgrading to 3.5.18 will make this work out of the box as intended.