### PR TITLE
Fixes #56

### DIFF
--- a/backend/backend/db.py
+++ b/backend/backend/db.py
@@ -106,8 +106,8 @@ class Neo4j:
                 statement = "CREATE INDEX ON : " + value + "(id)"
                 try:
                     self.query(statement)
-                except ClientError:
-                    pass
+                except ClientError as error:
+                    log.warning(error)
 
     def create_relationship(
         self,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ networks:
 
 services:
   stormspotter-neo4j:
-    image: neo4j:latest
+    image: neo4j:3.5.18
     restart: unless-stopped
     networks:
       - stormspotter-network
@@ -18,6 +18,17 @@ services:
       - NEO4J_dbms_memory_heap.initial_size=1G
       - NEO4J_dbms_memory_heap_max__size=1G
       - NEO4J_AUTH=neo4j/password
+    volumes:
+      - type: volume
+        source: logs
+        target: /logs
+        volume:
+          nocopy: true
+      - type: volume
+        source: data
+        target: /data
+        volume:
+          nocopy: true
 
   stormspotter-frontend:
     build:
@@ -41,3 +52,7 @@ services:
       - 9090:9090
     environment:
       - DOCKER_STORMSPOTTER=1
+
+volumes:
+  data:
+  logs:

--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:latest
 ENV VUE_APP_UPLOAD_URL=http://stormspotter-backend:9090/api/upload
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
Pins neo4j to `3.5.18` in `docker-compose.yml` (the last known version working with Stormspotter; 
This includes also the fix for #80